### PR TITLE
enable environment variable to override gdal-config --prefix as root directory of local GDAL installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,13 @@ Or you can install package directly from PyPi:
 
 Only a small set of GDAL versions is currently supported. At this point they are: ``1.8.1``, ``1.9.2``, ``1.10.0``, ``1.10.1``, ``1.11.0`` and ``1.11.1``. Package ``numpy`` is also listed as a dependency (using ``setup_requires`` and ``install_requires`` directives), so you do not need to install it before installing GDAL.
 
+If you installed GDAL using the `KyngChaos frameworks <http://www.kyngchaos.com/software/frameworks/>`_, you may need to override the default values returned by ``gdal-config --prefix`` in order to install this package. This can be accomplished by setting the ``GDALHOME`` environment variable, e.g.
+
+::
+
+  $ export GDALHOME="/Library/Frameworks/GDAL.framework/Versions/Current/unix/"
+  $ env/bin/pip install pygdal==1.8.1
+
 After package is installed you can use is same way as standard GDAL bindings:
 
 ::

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ from setuptools.command.build_ext import build_ext
 GDAL_VERSION = open('GDAL_VERSION', 'r').read().strip()
 PKG_VERSION = '0'
 
+ENV_GDALHOME = 'GDALHOME'
+
 
 class GDALConfigError(Exception):
     pass
@@ -55,9 +57,14 @@ class gdal_ext(build_ext):
 
         build_ext.finalize_options(self)
 
+        if ENV_GDALHOME in os.environ:
+            print 'GDAL prefix from environment variable %s' % ENV_GDALHOME
+            self.gdaldir = os.environ[ENV_GDALHOME]
+        else:
+            self.gdaldir = self.get_gdal_config('prefix')
+
         self.include_dirs.append(get_numpy_include())
 
-        self.gdaldir = self.get_gdal_config('prefix')
         self.library_dirs.append(os.path.join(self.gdaldir, 'lib'))
         self.include_dirs.append(os.path.join(self.gdaldir, 'include', 'gdal'))
         self.include_dirs.append(os.path.join(self.gdaldir, 'include'))


### PR DESCRIPTION
When installing GDAL on OS/X using one of the frameworks from here: http://kyngchaos.com/software/frameworks, the resulting installation places libraries and header files in a location that does not correspond to the value returned by gdal-config --prefix. This causes future installation of pygdal to fail, since it can't find the headers and libraries necessary to compile osgeo.

This PR enables the installation script to handle overrides to the GDAL root directory, as manipulated via an environment variable (GDALHOME)
